### PR TITLE
feat: add catalog link in the header

### DIFF
--- a/src/components/header/Header.css
+++ b/src/components/header/Header.css
@@ -8,11 +8,20 @@
   width: 100%;
 }
 
+.header__brand{
+  font-family: 'Comic Sans MS', cursive;
+  font-weight:  bold;
+  letter-spacing: 2px;
+  font-size: 1.2rem;
+}
+
 .header__link-list {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .header__profile-logout {
@@ -60,7 +69,7 @@ span {
   fill: black;
 }
 @media screen and (max-width: 480px) {
-  .header__login-register {
+  .header__login-register, .header__profile-logout {
     flex-direction: column;
     gap: 10px;
   }

--- a/src/components/header/Header.css
+++ b/src/components/header/Header.css
@@ -59,3 +59,9 @@ span {
 .header__link a:hover .header__icon {
   fill: black;
 }
+@media screen and (max-width: 480px) {
+  .header__login-register {
+    flex-direction: column;
+    gap: 10px;
+  }
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -27,6 +27,9 @@ export const Header = (): JSX.Element => {
             <Link to='/'>Home</Link>
           </li>
           <li className='header__link'>
+            <Link to='/catalog'>Catalog</Link>
+          </li>
+          <li className='header__link'>
             {customer ? (
               <div className='header__profile-logout'>
                 <Link to='/profile'>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -24,7 +24,9 @@ export const Header = (): JSX.Element => {
       <nav className='header__nav'>
         <ul className='header__link-list'>
           <li className='header__link'>
-            <Link to='/'>Home</Link>
+            <Link to='/'>
+              <span className='header__brand'>Flowers</span>
+            </Link>
           </li>
           <li className='header__link'>
             <Link to='/catalog'>Catalog</Link>


### PR DESCRIPTION
Task: [link](https://github.com/rolling-scopes-school/js-fe-course-en/blob/main/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_21.md)

Screenshot:
![image](https://github.com/NataliaIv90/ecommerce-app/assets/126329090/eb4f40d7-dad3-44af-a8c5-6b3dcdfa1972)



Deploy: [link](https://garden-with-flowers.netlify.app/)
score: 5/5
 Acceptance Criteria
A navigation option to the Catalog page is present in the website's header.
Clicking on the navigation option redirects the user to the Catalog page.