### PR TITLE
feat: add addresses editing functionality

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -5,6 +5,7 @@ import {
   CustomerDraft,
   Product,
   CustomerUpdate,
+  CustomerChangePassword,
 } from '@commercetools/platform-sdk/dist/declarations/src/generated';
 import { ByProjectKeyRequestBuilder } from '@commercetools/platform-sdk/dist/declarations/src/generated/client/by-project-key-request-builder';
 import { type ProductProjectionPagedQueryResponse } from '@commercetools/platform-sdk';
@@ -132,26 +133,19 @@ export class API {
     return result;
   }
 
-  // async changePassword(customerId: string, changePassword: CustomerChangePassword): Promise<Customer> {
-  //   let errorMsg = '';
-  //   const result: Customer = {} as Customer;
-  //   try {
-  //     const { body } = await this.client
-  //       .customers()
-  //       .withId({ ID: customerId })
-  //       .post({
-  //         body: changePassword,
-  //       })
-  //       .execute();
-  //     return body;
-  //   } catch (error) {
-  //     if (error instanceof Error) {
-  //       errorMsg = error.message;
-  //       alert(errorMsg);
-  //     }
-  //   }
-  //   return result;
-  // }
+  async changePassword(changePassword: CustomerChangePassword): Promise<Customer | null> {
+    let errorMsg = '';
+    try {
+      const { body } = await this.client.customers().password().post({ body: changePassword }).execute();
+      return body;
+    } catch (error) {
+      if (error instanceof Error) {
+        errorMsg = error.message;
+        alert(errorMsg);
+      }
+    }
+    return null;
+  }
 }
 
 // Export the API instance

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -131,6 +131,27 @@ export class API {
     }
     return result;
   }
+
+  // async changePassword(customerId: string, changePassword: CustomerChangePassword): Promise<Customer> {
+  //   let errorMsg = '';
+  //   const result: Customer = {} as Customer;
+  //   try {
+  //     const { body } = await this.client
+  //       .customers()
+  //       .withId({ ID: customerId })
+  //       .post({
+  //         body: changePassword,
+  //       })
+  //       .execute();
+  //     return body;
+  //   } catch (error) {
+  //     if (error instanceof Error) {
+  //       errorMsg = error.message;
+  //       alert(errorMsg);
+  //     }
+  //   }
+  //   return result;
+  // }
 }
 
 // Export the API instance

--- a/src/components/header/Header.css
+++ b/src/components/header/Header.css
@@ -8,9 +8,9 @@
   width: 100%;
 }
 
-.header__brand{
+.header__brand {
   font-family: 'Comic Sans MS', cursive;
-  font-weight:  bold;
+  font-weight: bold;
   letter-spacing: 2px;
   font-size: 1.2rem;
 }
@@ -69,7 +69,8 @@ span {
   fill: black;
 }
 @media screen and (max-width: 480px) {
-  .header__login-register, .header__profile-logout {
+  .header__login-register,
+  .header__profile-logout {
     flex-direction: column;
     gap: 10px;
   }

--- a/src/components/profile/Profile.css
+++ b/src/components/profile/Profile.css
@@ -17,7 +17,7 @@
 .profile-nav__item {
   border: none;
   outline: none;
-  color: #435;
+  color: #9ea0a2;
   cursor: pointer;
   background: none;
   padding: 1.2rem;
@@ -25,7 +25,7 @@
 }
 
 .profile-nav__item.active {
-  color: rgb(148, 113, 183);
+  color: #593825;
 }
 
 .profile-info {

--- a/src/components/profile/Profile.css
+++ b/src/components/profile/Profile.css
@@ -45,10 +45,17 @@
   .profile-wrapper {
     flex-direction: column;
     font-size: 12px;
+    padding-top: 3rem;
   }
 
   .profile-nav__list {
     display: flex;
     flex-direction: row;
+    gap: 0;
+  }
+
+  .profile-nav__item {
+    padding: 0.8rem;
+    text-align: center;
   }
 }

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,6 +6,7 @@ import { ProfileForm } from './profileForm/ProfileForm';
 const PROFILE_NAV_ITEMS = [
   { id: 'personal_info', displayName: 'Personal information' },
   { id: 'addresses', displayName: 'Addresses' },
+  // { id: 'reset_password', displayName: 'Reset password' },
 ];
 
 export const Profile = (): JSX.Element => {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -6,7 +6,7 @@ import { ProfileForm } from './profileForm/ProfileForm';
 const PROFILE_NAV_ITEMS = [
   { id: 'personal_info', displayName: 'Personal information' },
   { id: 'addresses', displayName: 'Addresses' },
-  // { id: 'reset_password', displayName: 'Reset password' },
+  { id: 'change_password', displayName: 'Change password' },
 ];
 
 export const Profile = (): JSX.Element => {

--- a/src/components/profile/addresses/Addresses.tsx
+++ b/src/components/profile/addresses/Addresses.tsx
@@ -1,0 +1,96 @@
+import { Address, Customer } from '@commercetools/platform-sdk';
+import ShippingAddressCard from './addressCard/ShippingAddressCard';
+import BillingAddressCard from './addressCard/BillingAddressCard';
+import { useState } from 'react';
+import AddBillingAddress from './addNewAddress/AddBillingAddress';
+import AddShippingAddress from './addNewAddress/AddShippingAddress';
+
+const Addresses = ({
+  customer,
+  shippingAddresses,
+  billingAddresses,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  shippingAddresses: Address[];
+  billingAddresses: Address[];
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const [showAddShippingAddress, setShowAddShippingAddress] = useState(false);
+  const [showAddBillingAddress, setShowAddBillingAddress] = useState(false);
+
+  const handleShowShippingTogle = (): void => {
+    setShowAddShippingAddress((prev) => !prev);
+  };
+
+  const handleShowBillingTogle = (): void => {
+    setShowAddBillingAddress((prev) => !prev);
+  };
+  return (
+    <div>
+      <h2>Shipping addresses</h2>
+      <div className='profile-form__spacer'></div>
+
+      {shippingAddresses?.map((address, index) => {
+        return (
+          <ShippingAddressCard
+            customer={customer}
+            address={address}
+            key={index}
+            handleEditToggle={handleEditToggle}
+          />
+        );
+      })}
+
+      {showAddShippingAddress && (
+        <AddShippingAddress
+          customer={customer}
+          handleShowTogle={handleShowShippingTogle}
+          handleEditToggle={handleEditToggle}
+        />
+      )}
+
+      <button
+        onClick={handleShowShippingTogle}
+        className='add-new-address'
+      >
+        Add Shipping Address
+      </button>
+      <div className='profile-form__spacer'></div>
+      <hr />
+      <hr />
+      <div className='profile-form__spacer'></div>
+
+      <h2>Billing addresses</h2>
+      <div className='profile-form__spacer'></div>
+
+      {billingAddresses?.map((address, index) => {
+        return (
+          <BillingAddressCard
+            customer={customer}
+            address={address}
+            key={index}
+            handleEditToggle={handleEditToggle}
+          />
+        );
+      })}
+
+      {showAddBillingAddress && (
+        <AddBillingAddress
+          customer={customer}
+          handleShowTogle={handleShowBillingTogle}
+          handleEditToggle={handleEditToggle}
+        />
+      )}
+
+      <button
+        onClick={handleShowBillingTogle}
+        className='add-new-address'
+      >
+        Add Billing Address
+      </button>
+    </div>
+  );
+};
+
+export default Addresses;

--- a/src/components/profile/addresses/addNewAddress/AddBillingAddress.tsx
+++ b/src/components/profile/addresses/addNewAddress/AddBillingAddress.tsx
@@ -1,0 +1,215 @@
+import { Customer } from '@commercetools/platform-sdk';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import { ECountrieOptions } from '../../../../types/types';
+import validationSchema from '../addressCard/billingAddressValidationSchema';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { OutlinedButton } from '../../../../shared/button/outlinedButton/OutlinedButton';
+import Input from '../../../../shared/ui/Input/Input';
+import { setLoading } from '../../../../store/slices/productSlice';
+import { useAppDispatch } from '../../../../hooks/reduxHooks';
+import { UpdateCustomer } from '../../../../store/slices/customerSlice';
+
+interface IAddBillingAddress {
+  billingAddress: IEditBillingAddress;
+}
+
+interface IEditBillingAddress {
+  streetName: string | undefined;
+  country: ECountrieOptions | undefined;
+  city: string | undefined;
+  postalCode: string | undefined;
+}
+
+type CountryCode = 'GE' | 'UZ' | 'UA';
+
+const countriesCodes: Record<string, CountryCode> = {
+  Georgia: 'GE',
+  Uzbekistan: 'UZ',
+  Ukraine: 'UA',
+};
+
+const AddBillingAddress = ({
+  customer,
+  handleShowTogle,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  handleShowTogle: () => void;
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const { control, handleSubmit } = useForm<IAddBillingAddress>({
+    defaultValues: {
+      billingAddress: {
+        city: '',
+        country: ECountrieOptions.ge,
+        postalCode: '',
+        streetName: '',
+      },
+    },
+    resolver: yupResolver(validationSchema) as Resolver<IAddBillingAddress>,
+    mode: 'all',
+  });
+
+  const onSubmit = (data: IAddBillingAddress) => {
+    if (
+      data.billingAddress.city &&
+      data.billingAddress.country &&
+      data.billingAddress.postalCode &&
+      data.billingAddress.streetName
+    ) {
+      const customerId = customer?.id || '';
+
+      const billingAddress = {
+        firstName: customer.firstName,
+        lastName: customer.lastName,
+        streetName: data.billingAddress.streetName.trim(),
+        postalCode: data.billingAddress.postalCode.trim(),
+        city: data.billingAddress.city.trim(),
+        country: countriesCodes[data.billingAddress.country],
+      };
+
+      const updatedFields = {
+        addBillingAddress: { address: billingAddress },
+      };
+
+      setLoading(true);
+      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+        if (UpdateCustomer.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            const address = customerData.addresses[customerData.addresses.length - 1];
+
+            const updatedFields = {
+              addBillingAddressId: { addressId: address.id },
+            };
+
+            void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+              if (UpdateCustomer.fulfilled.match(response)) {
+                const customerData = response.payload;
+                if (customerData) {
+                  alert('Profile Successfully updated!');
+                }
+                handleEditToggle();
+                handleShowTogle();
+                setLoading(false);
+              }
+            });
+          }
+        }
+      });
+    }
+  };
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div className={'address-container span-2'}>
+        <label
+          className='country-label'
+          htmlFor={'billingAddress.country'}
+        >
+          Country:
+        </label>
+        <Controller
+          control={control}
+          name={'billingAddress.country'}
+          render={({ field, fieldState }) => (
+            <>
+              <select
+                {...field}
+                name={'billingAddress.country'}
+                className='registration__select-input'
+                title='Shipping country'
+              >
+                {Object.entries(ECountrieOptions).map(([key, value]) => (
+                  <option
+                    key={key}
+                    value={value}
+                  >
+                    {value}
+                  </option>
+                ))}
+              </select>
+
+              {fieldState.error && <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>}
+            </>
+          )}
+        />
+
+        <label htmlFor={'billingAddress.streetName'}>Street: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.streetName'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.streetName'}
+              type='text'
+              id='street'
+              placeholder='Enter your street'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'billingAddress.city'}>City: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.city'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.city'}
+              type='text'
+              id='city'
+              placeholder='Enter your city'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'billingAddress.postalCode'}>Postal Code: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.postalCode'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.postalCode'}
+              type='text'
+              id='postalCode'
+              placeholder='Enter your postal code'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <button className='delete-address'>X</button>
+      </div>
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleShowTogle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AddBillingAddress;

--- a/src/components/profile/addresses/addNewAddress/AddShippingAddress.tsx
+++ b/src/components/profile/addresses/addNewAddress/AddShippingAddress.tsx
@@ -1,0 +1,215 @@
+import { Address, Customer } from '@commercetools/platform-sdk';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import { ECountrieOptions } from '../../../../types/types';
+import validationSchema from '../addressCard/shippingAddressValidationSchema';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { OutlinedButton } from '../../../../shared/button/outlinedButton/OutlinedButton';
+import Input from '../../../../shared/ui/Input/Input';
+import { setLoading } from '../../../../store/slices/productSlice';
+import { useAppDispatch } from '../../../../hooks/reduxHooks';
+import { UpdateCustomer } from '../../../../store/slices/customerSlice';
+
+interface IAddShippingAddress {
+  shippingAddress: IEditShippingAddress;
+}
+
+interface IEditShippingAddress {
+  streetName: string | undefined;
+  country: ECountrieOptions | undefined;
+  city: string | undefined;
+  postalCode: string | undefined;
+}
+
+type CountryCode = 'GE' | 'UZ' | 'UA';
+
+const countriesCodes: Record<string, CountryCode> = {
+  Georgia: 'GE',
+  Uzbekistan: 'UZ',
+  Ukraine: 'UA',
+};
+
+const AddShippingAddress = ({
+  customer,
+  handleShowTogle,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  handleShowTogle: () => void;
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const { control, handleSubmit } = useForm<IAddShippingAddress>({
+    defaultValues: {
+      shippingAddress: {
+        city: '',
+        country: ECountrieOptions.ge,
+        postalCode: '',
+        streetName: '',
+      },
+    },
+    resolver: yupResolver(validationSchema) as Resolver<IAddShippingAddress>,
+    mode: 'all',
+  });
+
+  const onSubmit = (data: IAddShippingAddress) => {
+    if (
+      data.shippingAddress.city &&
+      data.shippingAddress.country &&
+      data.shippingAddress.postalCode &&
+      data.shippingAddress.streetName
+    ) {
+      const customerId = customer?.id || '';
+
+      const shippingAddress = {
+        firstName: customer.firstName,
+        lastName: customer.lastName,
+        streetName: data.shippingAddress.streetName.trim(),
+        postalCode: data.shippingAddress.postalCode.trim(),
+        city: data.shippingAddress.city.trim(),
+        country: countriesCodes[data.shippingAddress.country],
+      };
+
+      const updatedFields = {
+        addShippingAddress: { address: shippingAddress },
+      };
+
+      setLoading(true);
+      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+        if (UpdateCustomer.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            const address = customerData.addresses[customerData.addresses.length - 1];
+
+            const updatedFields = {
+              addShippingAddressId: { addressId: address.id },
+            };
+
+            void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+              if (UpdateCustomer.fulfilled.match(response)) {
+                const customerData = response.payload;
+                if (customerData) {
+                  alert('Profile Successfully updated!');
+                }
+                handleEditToggle();
+                handleShowTogle();
+                setLoading(false);
+              }
+            });
+          }
+        }
+      });
+    }
+  };
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div className={'address-container span-2'}>
+        <label
+          className='country-label'
+          htmlFor={'shippingAddress.country'}
+        >
+          Country:
+        </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.country'}
+          render={({ field, fieldState }) => (
+            <>
+              <select
+                {...field}
+                name={'shippingAddress.country'}
+                className='registration__select-input'
+                title='Shipping country'
+              >
+                {Object.entries(ECountrieOptions).map(([key, value]) => (
+                  <option
+                    key={key}
+                    value={value}
+                  >
+                    {value}
+                  </option>
+                ))}
+              </select>
+
+              {fieldState.error && <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>}
+            </>
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.streetName'}>Street: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.streetName'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.streetName'}
+              type='text'
+              id='street'
+              placeholder='Enter your street'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.city'}>City: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.city'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.city'}
+              type='text'
+              id='city'
+              placeholder='Enter your city'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.postalCode'}>Postal Code: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.postalCode'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.postalCode'}
+              type='text'
+              id='postalCode'
+              placeholder='Enter your postal code'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <button className='delete-address'>X</button>
+      </div>
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleShowTogle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AddShippingAddress;

--- a/src/components/profile/addresses/addNewAddress/AddShippingAddress.tsx
+++ b/src/components/profile/addresses/addNewAddress/AddShippingAddress.tsx
@@ -1,4 +1,4 @@
-import { Address, Customer } from '@commercetools/platform-sdk';
+import { Customer } from '@commercetools/platform-sdk';
 import { Controller, Resolver, useForm } from 'react-hook-form';
 import { ECountrieOptions } from '../../../../types/types';
 import validationSchema from '../addressCard/shippingAddressValidationSchema';

--- a/src/components/profile/addresses/addressCard/BillingAddressCard.tsx
+++ b/src/components/profile/addresses/addressCard/BillingAddressCard.tsx
@@ -1,0 +1,257 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import { Address, Customer } from '@commercetools/platform-sdk';
+import { ECountrieOptions } from '../../../../types/types';
+import Input from '../../../../shared/ui/Input/Input';
+import addressesValidationSchema from './billingAddressValidationSchema';
+import { OutlinedButton } from '../../../../shared/button/outlinedButton/OutlinedButton';
+import { isDefault } from '../../helpers/helpers';
+import { setLoading } from '../../../../store/slices/productSlice';
+import { useAppDispatch } from '../../../../hooks/reduxHooks';
+import { UpdateCustomer } from '../../../../store/slices/customerSlice';
+
+interface IEditAddress {
+  billingAddress: IEditBillingAddress;
+}
+
+interface IEditBillingAddress {
+  streetName: string | undefined;
+  country: ECountrieOptions | undefined;
+  city: string | undefined;
+  postalCode: string | undefined;
+}
+
+type CountryCode = 'GE' | 'UZ' | 'UA';
+
+const countriesCodes: Record<string, CountryCode> = {
+  Georgia: 'GE',
+  Uzbekistan: 'UZ',
+  Ukraine: 'UA',
+};
+
+const BillingAddressCard = ({
+  customer,
+  address,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  address: Address;
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const dispatch = useAppDispatch();
+
+  const onSubmit = (data: IEditAddress) => {
+    if (
+      data.billingAddress.city !== address?.city ||
+      data.billingAddress.country !== address?.country ||
+      data.billingAddress.postalCode !== address?.postalCode ||
+      data.billingAddress.streetName !== address?.streetName
+    ) {
+      const customerId = customer?.id || '';
+      const updatedAddress: Address = {
+        firstName: customer?.firstName,
+        lastName: customer.lastName,
+        city: data.billingAddress.city?.trim(),
+        country: countriesCodes[data.billingAddress.country || address.country],
+        postalCode: data.billingAddress.postalCode?.trim(),
+        streetName: data.billingAddress.streetName?.trim(),
+      };
+
+      const updatedFields = {
+        changeBillingAddress: { addressId: address.id, address: updatedAddress },
+      };
+
+      setLoading(true);
+      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+        if (UpdateCustomer.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            alert('Profile Successfully updated!');
+          }
+          handleEditToggle();
+          setLoading(false);
+        }
+      });
+    }
+  };
+
+  const handleDelete = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+    const customerId = customer?.id || '';
+    const updatedFields = {
+      removeAddress: { addressId: address.id },
+    };
+    void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+      if (UpdateCustomer.fulfilled.match(response)) {
+        const customerData = response.payload;
+        if (customerData) {
+          alert('Address Successfully Deleted!');
+        }
+        handleEditToggle();
+        setLoading(false);
+      }
+    });
+  };
+
+  const handleSetAsDefault = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+    const customerId = customer?.id || '';
+    const updatedFields = {
+      setDefaultBillingAddress: { addressId: address.id },
+    };
+    void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+      if (UpdateCustomer.fulfilled.match(response)) {
+        const customerData = response.payload;
+        if (customerData) {
+          alert('Address Successfully Set As Default!');
+        }
+        handleEditToggle();
+        setLoading(false);
+      }
+    });
+  };
+
+  const { control, handleSubmit } = useForm<IEditAddress>({
+    defaultValues: {
+      billingAddress: {
+        streetName: address.streetName,
+        country: Object.keys(countriesCodes).find((key) => countriesCodes[key] === address.country) as ECountrieOptions,
+        city: address.city,
+        postalCode: address.postalCode,
+      },
+    },
+    resolver: yupResolver(addressesValidationSchema) as Resolver<IEditAddress>,
+    mode: 'all',
+  });
+
+  const isDefaultBillingAddress = isDefault(address, customer?.defaultBillingAddressId);
+
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div className={'address-container span-2' + (isDefaultBillingAddress ? ' default' : '')}>
+        {isDefaultBillingAddress ? <h3 className='span-2'>Default Billing Address</h3> : null}
+
+        <label
+          className='country-label'
+          htmlFor={'billingAddress.country'}
+        >
+          Country:
+        </label>
+        <Controller
+          control={control}
+          name={'billingAddress.country'}
+          render={({ field, fieldState }) => (
+            <>
+              <select
+                {...field}
+                name={'billingAddress.country'}
+                className='registration__select-input'
+                title='Shipping country'
+              >
+                {Object.entries(ECountrieOptions).map(([key, value]) => (
+                  <option
+                    key={key}
+                    value={value}
+                  >
+                    {value}
+                  </option>
+                ))}
+              </select>
+
+              {fieldState.error && <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>}
+            </>
+          )}
+        />
+
+        <label htmlFor={'billingAddress.streetName'}>Street: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.streetName'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.streetName'}
+              type='text'
+              id='street'
+              placeholder='Enter your street'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'billingAddress.city'}>City: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.city'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.city'}
+              type='text'
+              id='city'
+              placeholder='Enter your city'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'billingAddress.postalCode'}>Postal Code: </label>
+        <Controller
+          control={control}
+          name={'billingAddress.postalCode'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'billingAddress.postalCode'}
+              type='text'
+              id='postalCode'
+              placeholder='Enter your postal code'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <button
+          onClick={handleDelete}
+          className='delete-address'
+        >
+          X
+        </button>
+
+        {!isDefaultBillingAddress && (
+          <button
+            onClick={handleSetAsDefault}
+            className='set-as-default'
+          >
+            Set As Default Billing Address
+          </button>
+        )}
+      </div>
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleEditToggle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default BillingAddressCard;

--- a/src/components/profile/addresses/addressCard/ShippingAddressCard.tsx
+++ b/src/components/profile/addresses/addressCard/ShippingAddressCard.tsx
@@ -1,0 +1,261 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import { Address, Customer } from '@commercetools/platform-sdk';
+import { ECountrieOptions } from '../../../../types/types';
+import Input from '../../../../shared/ui/Input/Input';
+import addressesValidationSchema from './shippingAddressValidationSchema';
+import { OutlinedButton } from '../../../../shared/button/outlinedButton/OutlinedButton';
+import { isDefault } from '../../helpers/helpers';
+import { setLoading } from '../../../../store/slices/productSlice';
+import { UpdateCustomer } from '../../../../store/slices/customerSlice';
+import { useAppDispatch } from '../../../../hooks/reduxHooks';
+
+interface IEditAddress {
+  shippingAddress: IEditShippingAddress;
+}
+
+interface IEditShippingAddress {
+  streetName: string | undefined;
+  country: ECountrieOptions | undefined;
+  city: string | undefined;
+  postalCode: string | undefined;
+}
+
+type CountryCode = 'GE' | 'UZ' | 'UA';
+
+const countriesCodes: Record<string, CountryCode> = {
+  Georgia: 'GE',
+  Uzbekistan: 'UZ',
+  Ukraine: 'UA',
+};
+
+const AddressCard = ({
+  customer,
+  address,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  address: Address;
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const dispatch = useAppDispatch();
+
+  const onSubmit = (data: IEditAddress) => {
+    if (
+      data.shippingAddress.city !== address?.city ||
+      data.shippingAddress.country !== address?.country ||
+      data.shippingAddress.postalCode !== address?.postalCode ||
+      data.shippingAddress.streetName !== address?.streetName
+    ) {
+      const customerId = customer?.id || '';
+      const updatedAddress: Address = {
+        firstName: customer?.firstName,
+        lastName: customer.lastName,
+        city: data.shippingAddress.city,
+        country: countriesCodes[data.shippingAddress.country || address.country],
+        postalCode: data.shippingAddress.postalCode,
+        streetName: data.shippingAddress.streetName,
+      };
+
+      const updatedFields = {
+        changeShippingAddress: { addressId: address.id, address: updatedAddress },
+      };
+
+      setLoading(true);
+      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+        if (UpdateCustomer.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            alert('Profile Successfully updated!');
+          }
+          handleEditToggle();
+          setLoading(false);
+        }
+      });
+    }
+  };
+
+  const isDefaultShippingAddress = isDefault(address, customer?.defaultShippingAddressId);
+
+  const { control, handleSubmit } = useForm<IEditAddress>({
+    defaultValues: {
+      shippingAddress: {
+        streetName: address.streetName,
+        country: Object.keys(countriesCodes).find((key) => countriesCodes[key] === address.country) as ECountrieOptions,
+        city: address.city,
+        postalCode: address.postalCode,
+      },
+    },
+    resolver: yupResolver(addressesValidationSchema) as Resolver<IEditAddress>,
+    mode: 'all',
+  });
+
+  const handleDelete = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+    const customerId = customer?.id || '';
+    const updatedFields = {
+      removeAddress: { addressId: address.id },
+    };
+    void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+      if (UpdateCustomer.fulfilled.match(response)) {
+        const customerData = response.payload;
+        if (customerData) {
+          alert('Address Successfully Deleted!');
+        }
+        handleEditToggle();
+        setLoading(false);
+      }
+    });
+  };
+
+  const handleSetAsDefault = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+    const customerId = customer?.id || '';
+    const updatedFields = {
+      setDefaultShippingAddress: { addressId: address.id },
+    };
+    void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+      if (UpdateCustomer.fulfilled.match(response)) {
+        const customerData = response.payload;
+        if (customerData) {
+          alert('Address Successfully Set As Default!!');
+        }
+        handleEditToggle();
+        setLoading(false);
+      }
+    });
+  };
+
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div
+        key={address.id}
+        className={'address-container span-2' + (isDefaultShippingAddress ? ' default' : '')}
+      >
+        {isDefaultShippingAddress ? <h3 className='span-2'>Default Shipping Address</h3> : null}
+
+        <label
+          className='country-label'
+          htmlFor={'shippingAddress.country'}
+        >
+          Country:
+        </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.country'}
+          render={({ field, fieldState }) => (
+            <>
+              <select
+                {...field}
+                name={'shippingAddress.country'}
+                className='registration__select-input'
+                title='Shipping country'
+              >
+                {Object.entries(ECountrieOptions).map(([key, value]) => (
+                  <option
+                    key={key}
+                    value={value}
+                  >
+                    {value}
+                  </option>
+                ))}
+              </select>
+
+              {fieldState.error && <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>}
+            </>
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.streetName'}>Street: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.streetName'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.streetName'}
+              type='text'
+              id='street'
+              placeholder='Enter your street'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.city'}>City: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.city'}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.city'}
+              type='text'
+              id='city'
+              placeholder='Enter your city'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor={'shippingAddress.postalCode'}>Postal Code: </label>
+        <Controller
+          control={control}
+          name={'shippingAddress.postalCode'}
+          defaultValue={address.postalCode}
+          render={({ field, fieldState }) => (
+            <Input
+              name={'shippingAddress.postalCode'}
+              type='text'
+              id='postalCode'
+              placeholder='Enter your postal code'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <button
+          onClick={handleDelete}
+          className='delete-address'
+        >
+          X
+        </button>
+
+        {!isDefaultShippingAddress && (
+          <button
+            onClick={handleSetAsDefault}
+            className='set-as-default'
+          >
+            Set As Default Shipping Address
+          </button>
+        )}
+      </div>
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleEditToggle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AddressCard;

--- a/src/components/profile/addresses/addressCard/billingAddressValidationSchema.ts
+++ b/src/components/profile/addresses/addressCard/billingAddressValidationSchema.ts
@@ -1,0 +1,27 @@
+import * as Yup from 'yup';
+import { ECountrieOptions } from '../../../../types/types';
+
+const addressSchema = Yup.object().shape({
+  streetName: Yup.string().min(1, 'Street should be min 1 character'),
+  city: Yup.string()
+    .min(1, 'City should be min 1 characters')
+    .matches(/^([A-Z][a-z]*)$/g, 'City can only contain latin letters, start from capital letter'),
+  country: Yup.string().oneOf([ECountrieOptions.ge, ECountrieOptions.ua, ECountrieOptions.uz]),
+  postalCode: Yup.string().when(['country'], (country: ECountrieOptions[], schema) => {
+    if (country[0] === ECountrieOptions.ua) {
+      return schema.matches(/^\d{5}$/, 'Invalid postal code format for Ukraine');
+    } else if (country[0] === ECountrieOptions.uz) {
+      return schema.matches(/^\d{6}$/, 'Invalid postal code format for Uzbekistan');
+    } else if (country[0] === ECountrieOptions.ge) {
+      return schema.matches(/^\d{4}$/, 'Invalid postal code format for Georgia');
+    } else {
+      return schema;
+    }
+  }),
+});
+
+const validationSchema = Yup.object().shape({
+  billingAddress: addressSchema,
+});
+
+export default validationSchema;

--- a/src/components/profile/addresses/addressCard/shippingAddressValidationSchema.ts
+++ b/src/components/profile/addresses/addressCard/shippingAddressValidationSchema.ts
@@ -1,0 +1,27 @@
+import * as Yup from 'yup';
+import { ECountrieOptions } from '../../../../types/types';
+
+const addressSchema = Yup.object().shape({
+  streetName: Yup.string().min(1, 'Street should be min 1 character'),
+  city: Yup.string()
+    .min(1, 'City should be min 1 characters')
+    .matches(/^([A-Z][a-z]*)$/g, 'City can only contain latin letters, start from capital letter'),
+  country: Yup.string().oneOf([ECountrieOptions.ge, ECountrieOptions.ua, ECountrieOptions.uz]),
+  postalCode: Yup.string().when(['country'], (country: ECountrieOptions[], schema) => {
+    if (country[0] === ECountrieOptions.ua) {
+      return schema.matches(/^\d{5}$/, 'Invalid postal code format for Ukraine');
+    } else if (country[0] === ECountrieOptions.uz) {
+      return schema.matches(/^\d{6}$/, 'Invalid postal code format for Uzbekistan');
+    } else if (country[0] === ECountrieOptions.ge) {
+      return schema.matches(/^\d{4}$/, 'Invalid postal code format for Georgia');
+    } else {
+      return schema;
+    }
+  }),
+});
+
+const validationSchema = Yup.object().shape({
+  shippingAddress: addressSchema,
+});
+
+export default validationSchema;

--- a/src/components/profile/addresses/addressesValidation.ts
+++ b/src/components/profile/addresses/addressesValidation.ts
@@ -1,0 +1,30 @@
+import * as Yup from 'yup';
+import { ECountrieOptions } from '../../../types/types';
+
+const addressSchema = Yup.array(
+  Yup.object().shape({
+    street: Yup.string().min(1, 'Street should be min 1 character'),
+    city: Yup.string()
+      .min(1, 'City should be min 1 characters')
+      .matches(/^([A-Z][a-z]*)$/g, 'City can only contain latin letters, start from capital letter'),
+    country: Yup.string().oneOf([ECountrieOptions.ge, ECountrieOptions.ua, ECountrieOptions.uz]),
+    postalCode: Yup.string().when(['country'], (country: ECountrieOptions[], schema) => {
+      if (country[0] === ECountrieOptions.ua) {
+        return schema.matches(/^\d{5}$/, 'Invalid postal code format for Ukraine');
+      } else if (country[0] === ECountrieOptions.uz) {
+        return schema.matches(/^\d{6}$/, 'Invalid postal code format for Uzbekistan');
+      } else if (country[0] === ECountrieOptions.ge) {
+        return schema.matches(/^\d{4}$/, 'Invalid postal code format for Georgia');
+      } else {
+        return schema;
+      }
+    }),
+  })
+);
+
+const validationSchema = Yup.object().shape({
+  shippingAddresses: addressSchema,
+  billingAddresses: addressSchema,
+});
+
+export default validationSchema;

--- a/src/components/profile/helpers/helpers.ts
+++ b/src/components/profile/helpers/helpers.ts
@@ -1,34 +1,26 @@
 import { Address, Customer } from '@commercetools/platform-sdk';
 
 export const getShippingAddresses = (customer: Customer | null): Address[] | [] => {
-  if (!customer) return [];
-  return customer.addresses.filter((address: Address) => {
-    let temp;
-    customer.shippingAddressIds?.forEach((id) => {
-      if (id === address.id) {
-        temp = address;
-        return;
-      }
-    });
+  if (!customer || !Object.keys(customer).length) return [];
 
-    return temp;
+  return customer?.addresses?.filter((address: Address) => {
+    // eslint-disable-next-line array-callback-return
+    if (!address.id) return;
+
+    return customer?.shippingAddressIds?.includes(address.id);
   });
 };
 
 export const getBillinggAddresses = (customer: Customer | null): Address[] | [] => {
-  if (!customer) return [];
-  return customer.addresses.filter((address: Address) => {
-    let temp;
-    customer.shippingAddressIds?.forEach((id) => {
-      if (id === address.id) {
-        temp = address;
-        return;
-      }
-    });
+  if (!customer || !Object.keys(customer).length) return [];
 
-    return temp;
+  return customer?.addresses?.filter((address: Address) => {
+    // eslint-disable-next-line array-callback-return
+    if (!address.id) return;
+
+    return customer?.billingAddressIds?.includes(address.id);
   });
 };
 
 export const isDefault = (address: Address, defaultAddressId: string | undefined): boolean =>
-  address.id === defaultAddressId;
+  address?.id === defaultAddressId;

--- a/src/components/profile/personalDetails/PersonalDetails.tsx
+++ b/src/components/profile/personalDetails/PersonalDetails.tsx
@@ -1,0 +1,170 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import Input from '../../../shared/ui/Input/Input';
+import { Customer } from '@commercetools/platform-sdk';
+import personalDetailsValidationSchema from './validatePersonalDetails';
+import { OutlinedButton } from '../../../shared/button/outlinedButton/OutlinedButton';
+import { setLoading } from '../../../store/slices/productSlice';
+import { useAppDispatch } from '../../../hooks/reduxHooks';
+import { UpdateCustomer } from '../../../store/slices/customerSlice';
+
+interface IEditPersonalDetails {
+  firstName: string;
+  lastName: string;
+  email: string;
+  dateOfBirth: Date;
+}
+
+const PersoanlDetails = ({
+  customer,
+  handleEditToggle,
+}: {
+  customer: Customer;
+  handleEditToggle: () => void;
+}): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const { control, handleSubmit } = useForm<IEditPersonalDetails>({
+    defaultValues: {
+      firstName: customer?.firstName,
+      lastName: customer?.lastName,
+      email: customer?.email,
+      dateOfBirth: new Date(customer?.dateOfBirth || '1900-01-01'),
+    },
+    resolver: yupResolver(personalDetailsValidationSchema) as Resolver<IEditPersonalDetails>,
+    mode: 'all',
+  });
+
+  const onSubmit = (data: IEditPersonalDetails) => {
+    // Format date of birth
+    const year = data.dateOfBirth.getFullYear();
+    const month = String(data.dateOfBirth.getMonth() + 1).padStart(2, '0');
+    const day = String(data.dateOfBirth.getDate()).padStart(2, '0');
+    const formattedDate = `${year}-${month}-${day}`;
+
+    if (
+      data.email.trim() !== customer?.email ||
+      data.firstName.trim() !== customer?.firstName ||
+      data.lastName.trim() !== customer?.lastName ||
+      formattedDate !== customer?.dateOfBirth
+    ) {
+      const customerId = customer?.id || '';
+      const updatedFields = {
+        setFirstName: { firstName: data.firstName.trim() },
+        setLastName: { lastName: data.lastName.trim() },
+        setEmail: { email: data.email.trim() },
+        setDateOfBirth: { dateOfBirth: formattedDate },
+      };
+
+      setLoading(true);
+      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
+        if (UpdateCustomer.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            alert('Profile Successfully updated!');
+          }
+          handleEditToggle();
+          setLoading(false);
+        }
+      });
+    }
+  };
+
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <>
+        <label htmlFor='firstName'>First Name: </label>
+        <Controller
+          control={control}
+          name='firstName'
+          render={({ field, fieldState }) => (
+            <Input
+              name='firstName'
+              type='text'
+              id='firstName'
+              placeholder='Enter your first name'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor='lastName'>Last Name: </label>
+        <Controller
+          control={control}
+          name='lastName'
+          render={({ field, fieldState }) => (
+            <Input
+              name='lastName'
+              type='text'
+              id='lastName'
+              placeholder='Enter your last name'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor='email'>Email: </label>
+        <Controller
+          control={control}
+          name='email'
+          render={({ field, fieldState }) => (
+            <Input
+              name='email'
+              type='text'
+              id='email'
+              placeholder='Enter your email'
+              autoComplete='email'
+              value={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <label htmlFor='dateOfBirth'>Date of birth: </label>
+
+        <Controller
+          control={control}
+          name='dateOfBirth'
+          render={({ field, fieldState }) => (
+            <Input
+              name='dateOfBirth'
+              type='date'
+              id='dateOfBirth'
+              placeholder='Enter your date of birth'
+              value={field.value instanceof Date ? field.value.toISOString().substr(0, 10) : field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+      </>
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleEditToggle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default PersoanlDetails;

--- a/src/components/profile/personalDetails/validatePersonalDetails.ts
+++ b/src/components/profile/personalDetails/validatePersonalDetails.ts
@@ -1,0 +1,18 @@
+import * as Yup from 'yup';
+
+const validationSchema = Yup.object().shape({
+  email: Yup.string().email().min(5, 'Email should be min 5 symbols').max(50, 'This email is too long'),
+  firstName: Yup.string()
+    .min(1, 'Name should be min 1 characters')
+    .max(50, 'This name is too long')
+    .matches(/^([A-Z][a-z]*)$/g, 'Name can only contain latin letters, start from capital letter'),
+  lastName: Yup.string()
+    .min(1, 'Surname should be min 2 characters')
+    .max(50, 'This surname is too long')
+    .matches(/^([A-Z][a-z]*)$/g, 'Surname can only contain latin letters,  start from capital letter'),
+  dateOfBirth: Yup.date()
+    .min(new Date('1900-01-01'), 'Date must be after 1900')
+    .max(new Date(new Date().getFullYear() - 13, 11, 31), 'User should be at least 13 years'),
+});
+
+export default validationSchema;

--- a/src/components/profile/profileForm/ProfileForm.css
+++ b/src/components/profile/profileForm/ProfileForm.css
@@ -19,10 +19,6 @@
   display: inline-block;
 }
 
-.profile-form .error_visibility {
-  margin-left: 150px;
-}
-
 .profile-form label,
 .profile-form .country-label {
   margin-right: 20px;

--- a/src/components/profile/profileForm/ProfileForm.css
+++ b/src/components/profile/profileForm/ProfileForm.css
@@ -1,3 +1,9 @@
+.profile-form {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  width: 80%;
+}
+
 .profile-form input,
 .profile-form select {
   border: none;
@@ -26,7 +32,8 @@
 }
 
 .profile-form label {
-  bottom: 25px;
+  display: flex;
+  align-items: center;
 }
 
 .profile-form .editting-btns-container {
@@ -34,7 +41,12 @@
   justify-content: center;
   gap: 30px;
   flex-wrap: wrap;
+  grid-column: span 2;
   width: 100%;
+}
+
+.span-2 {
+  grid-column: span 2;
 }
 
 .profile-form .outlinedButton {
@@ -79,15 +91,25 @@
   gap: 30px;
 }
 
-.address-container {
+.profile-form .address-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   position: relative;
-  padding: 0.8rem;
+  padding: 3rem 0.8rem 0.8rem 0.8rem;
   background: #f5f4f4;
   width: 100%;
 }
 
-.address-container.default {
+.address-container.default,
+.address-container.no-edit.default {
   background: rgb(247, 240, 232);
+  padding: 0.8rem;
+}
+
+.address-container.no-edit {
+  background: #f5f4f4;
+  margin: 20px 0;
+  padding: 0.8rem;
 }
 
 .add-new-address {
@@ -102,13 +124,14 @@
   color: #000;
 }
 
-.add-new-address:hover {
+.add-new-address:hover,
+.set-as-default:hover {
   color: #fff;
   background-color: rgb(188, 188, 188);
 }
 
-.delete-address {
-  margin: 1.2rem;
+.delete-address,
+.set-as-default {
   border: none;
   outline: none;
   padding: 0.6rem 0.8rem;
@@ -118,8 +141,13 @@
   background-color: rgb(188, 188, 188);
   fill: #fff;
   position: absolute;
-  right: 10px;
-  top: 10px;
+  right: -50px;
+  top: 5px;
+}
+
+.set-as-default {
+  right: 5px;
+  top: 5px;
 }
 
 .delete-address:hover {
@@ -139,4 +167,9 @@
 .address__label-value-wrapper span,
 .profile-details span {
   color: #000;
+}
+
+.profile-form__spacer {
+  display: block;
+  margin: 20px 0;
 }

--- a/src/components/profile/profileForm/ProfileForm.tsx
+++ b/src/components/profile/profileForm/ProfileForm.tsx
@@ -1,17 +1,10 @@
-import Input from '../../../shared/ui/Input/Input';
-import { ECountrieOptions, IRegisterData } from '../../../types/types';
-import { useForm, Controller, SubmitHandler, Resolver } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
-import { useAppDispatch, useAppSelector } from '../../../hooks/reduxHooks';
-import { UpdateCustomer } from '../../../store/slices/customerSlice';
+import { useAppSelector } from '../../../hooks/reduxHooks';
 import { useState } from 'react';
-import { OutlinedButton } from '../../../shared/button/outlinedButton/OutlinedButton';
-import { Loader } from '../../../shared/ui/Loader/Loader';
-
-import './ProfileForm.css';
-import { validationSchema } from '../validation/validation';
 import { getBillinggAddresses, getShippingAddresses, isDefault } from '../helpers/helpers';
 import { Address } from '@commercetools/platform-sdk';
+import PersoanlDetails from '../personalDetails/PersonalDetails';
+import Addresses from '../addresses/Addresses';
+import './ProfileForm.css';
 
 interface IProfileFormProps {
   selectedItem: string;
@@ -19,412 +12,35 @@ interface IProfileFormProps {
 
 export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element => {
   const [isEditing, setIsEditing] = useState(false);
-  const dispatch = useAppDispatch();
   const customer = useAppSelector((state) => state.customers.customer);
-  const [isLoading, setLoading] = useState(false);
 
-  const onSubmit: SubmitHandler<IRegisterData> = (data: IRegisterData) => {
-    const year = data.dateOfBirth.getFullYear();
-    const month = String(data.dateOfBirth.getMonth() + 1).padStart(2, '0');
-    const day = String(data.dateOfBirth.getDate()).padStart(2, '0');
-    const formattedDate = `${year}-${month}-${day}`;
-
-    if (
-      data.email ||
-      data.password ||
-      data.firstName.trim() !== customer?.firstName ||
-      data.lastName.trim() !== customer?.lastName ||
-      formattedDate !== customer?.dateOfBirth ||
-      data.shippingAddress.country
-    ) {
-      const customerId = customer?.id || '';
-
-      const updatedFields = {
-        setFirstName: { firstName: data.firstName.trim() },
-        setLastName: { lastName: data.lastName.trim() },
-        setDateOfBirth: { dateOfBirth: formattedDate },
-      };
-
-      setLoading(true);
-      void dispatch(UpdateCustomer({ customerId, updatedFields })).then((response) => {
-        if (UpdateCustomer.fulfilled.match(response)) {
-          const customerData = response.payload;
-          if (customerData) {
-            alert('Profile Successfully updated!');
-          }
-          setLoading(false);
-        }
-      });
-    }
-  };
-
-  const shippingAddresses: Address[] = getShippingAddresses(customer);
-  const billingAddresses: Address[] = getBillinggAddresses(customer);
-
-  const shippingAddress = {
-    city: '',
-    country: ECountrieOptions.ge,
-    postalCode: '',
-    street: '',
-  };
-
-  let billingAddress = {
-    city: '',
-    country: ECountrieOptions.ge,
-    postalCode: '',
-    street: '',
-  };
-
-  if (customer?.addresses && customer?.addresses.length === 2) {
-    const sAddress = customer.addresses[0];
-    const bAddress = customer.addresses[1];
-
-    shippingAddress.city = sAddress.city || '';
-    shippingAddress.postalCode = sAddress.postalCode || '';
-    shippingAddress.street = sAddress.streetName || '';
-
-    billingAddress.city = bAddress.city || '';
-    billingAddress.postalCode = bAddress.postalCode || '';
-    billingAddress.street = bAddress.streetName || '';
-  }
-  if (customer?.addresses && customer?.addresses.length === 1) {
-    const address = customer.addresses[0];
-    shippingAddress.city = address.city || '';
-    shippingAddress.postalCode = address.postalCode || '';
-    shippingAddress.street = address.streetName || '';
-    billingAddress = shippingAddress;
-  }
-
-  const { control, handleSubmit } = useForm<IRegisterData>({
-    defaultValues: {
-      firstName: customer?.firstName,
-      lastName: customer?.lastName,
-      dateOfBirth: new Date(customer?.dateOfBirth || '1900-01-01'),
-      shippingAddress: shippingAddress,
-      billingAddress: billingAddress,
-    },
-    resolver: yupResolver(validationSchema) as Resolver<IRegisterData>,
-    mode: 'all',
-  });
+  const shippingAddresses: Address[] | [] = getShippingAddresses(customer);
+  const billingAddresses: Address[] | [] = getBillinggAddresses(customer);
 
   const handleEditToggle = () => {
-    setIsEditing(!isEditing);
+    setIsEditing((prev) => !prev);
   };
 
   return (
     <div>
       {isEditing ? (
-        <form
-          className='profile-form'
-          onSubmit={handleSubmit(onSubmit)}
-        >
-          {selectedItem === 'personal_info' ? (
-            <>
-              <label htmlFor='firstName'>First Name: </label>
-              <Controller
-                control={control}
-                name='firstName'
-                render={({ field, fieldState }) => (
-                  <Input
-                    name='firstName'
-                    type='text'
-                    id='firstName'
-                    placeholder='Enter your first name'
-                    value={field.value}
-                    onChange={field.onChange}
-                    onBlur={field.onBlur}
-                    error={fieldState.error?.message}
-                  />
-                )}
-              />
-
-              <br />
-
-              <label htmlFor='lastName'>Last Name: </label>
-              <Controller
-                control={control}
-                name='lastName'
-                render={({ field, fieldState }) => (
-                  <Input
-                    name='lastName'
-                    type='text'
-                    id='lastName'
-                    placeholder='Enter your last name'
-                    value={field.value}
-                    onChange={field.onChange}
-                    onBlur={field.onBlur}
-                    error={fieldState.error?.message}
-                  />
-                )}
-              />
-
-              <br />
-
-              <label htmlFor='dateOfBirth'>Date of birth: </label>
-
-              <Controller
-                control={control}
-                name='dateOfBirth'
-                render={({ field, fieldState }) => (
-                  <Input
-                    name='dateOfBirth'
-                    type='date'
-                    id='dateOfBirth'
-                    placeholder='Enter your date of birth'
-                    value={field.value instanceof Date ? field.value.toISOString().substr(0, 10) : field.value}
-                    onChange={field.onChange}
-                    onBlur={field.onBlur}
-                    error={fieldState.error?.message}
-                  />
-                )}
-              />
-            </>
-          ) : null}
-
-          <br />
-
-          {selectedItem === 'addresses' ? (
-            <>
-              <h2>Shipping addresses</h2>
-              <br />
-              {shippingAddresses?.map((address) => {
-                const isDefaultShippingAddress = isDefault(address, customer?.defaultShippingAddressId);
-                return (
-                  <div
-                    key={address.id}
-                    className={'address-container' + (isDefaultShippingAddress ? ' default' : '')}
-                  >
-                    {isDefaultShippingAddress ? <h3>Default Shipping Address</h3> : null}
-                    <br />
-                    <label
-                      className='country-label'
-                      htmlFor='shippingAddressCountry'
-                    >
-                      Country:{' '}
-                    </label>
-                    <Controller
-                      control={control}
-                      name='shippingAddress.country'
-                      render={({ field, fieldState }) => (
-                        <>
-                          <select
-                            {...field}
-                            name='shippingAddressCountry'
-                            className='registration__select-input'
-                            title='Shipping country'
-                          >
-                            {Object.entries(ECountrieOptions).map(([key, value]) => (
-                              <option
-                                key={key}
-                                value={value}
-                              >
-                                {value}
-                              </option>
-                            ))}
-                          </select>
-
-                          {fieldState.error && (
-                            <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>
-                          )}
-                        </>
-                      )}
-                    />
-
-                    <br />
-
-                    <label htmlFor='shippingAddress.street'>Street: </label>
-                    <Controller
-                      control={control}
-                      name='shippingAddress.street'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          name='shippingAddress.street'
-                          type='text'
-                          id='street'
-                          placeholder='Enter your street'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <br />
-
-                    <label htmlFor='shippingAddress.city'>City: </label>
-                    <Controller
-                      control={control}
-                      name='shippingAddress.city'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          name='shippingAddress.city'
-                          type='text'
-                          id='city'
-                          placeholder='Enter your city'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <br />
-
-                    <label htmlFor='shippingAddress.postalCode'>Postal Code: </label>
-                    <Controller
-                      control={control}
-                      name='shippingAddress.postalCode'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          type='text'
-                          id='postalCode'
-                          placeholder='Enter your postal code'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <button className='delete-address'>X</button>
-                  </div>
-                );
-              })}
-
-              <button className='add-new-address'>Add Shipping Address</button>
-
-              <br />
-
-              <h2>Billing addresses</h2>
-
-              <br />
-
-              {billingAddresses?.map((address) => {
-                const isDefaultBillingAddress = isDefault(address, customer?.defaultBillingAddressId);
-
-                return (
-                  <div
-                    key={address.id}
-                    className={'address-container' + (isDefaultBillingAddress ? ' default' : '')}
-                  >
-                    {isDefaultBillingAddress ? <h3>Default Billing Address</h3> : null}
-                    <br />
-                    <label
-                      className='country-label'
-                      htmlFor='billingAddressCountry'
-                    >
-                      Country:{' '}
-                    </label>
-                    <Controller
-                      control={control}
-                      name='billingAddress.country'
-                      render={({ field, fieldState }) => (
-                        <>
-                          <select
-                            {...field}
-                            name='billingAddressCountry'
-                            className='registration__select-input'
-                            title='Billing address country'
-                          >
-                            {Object.entries(ECountrieOptions).map(([key, value]) => (
-                              <option
-                                key={key}
-                                value={value}
-                              >
-                                {value}
-                              </option>
-                            ))}
-                          </select>
-
-                          {fieldState.error && (
-                            <p className={fieldState.error ? 'error' : ''}>{fieldState.error.message}</p>
-                          )}
-                        </>
-                      )}
-                    />
-
-                    <br />
-                    <label htmlFor='billingAddress.street'>Street: </label>
-                    <Controller
-                      control={control}
-                      name='billingAddress.street'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          name='billingAddress.street'
-                          type='text'
-                          id='streetBilling'
-                          placeholder='Enter your street'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <br />
-                    <label htmlFor='billingAddress.city'>City: </label>
-                    <Controller
-                      control={control}
-                      name='billingAddress.city'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          type='text'
-                          id='cityBilling'
-                          placeholder='Enter your city'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <br />
-                    <label htmlFor='billingAddress.postalCode'>Postal Code: </label>
-                    <Controller
-                      control={control}
-                      name='billingAddress.postalCode'
-                      render={({ field, fieldState }) => (
-                        <Input
-                          name='billingAddress.postalCode'
-                          type='text'
-                          id='postalCodeBilling'
-                          placeholder='Enter your postal code'
-                          value={field.value}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          error={fieldState.error?.message}
-                        />
-                      )}
-                    />
-
-                    <button className='delete-address'>X</button>
-                  </div>
-                );
-              })}
-              <button className='add-new-address'>Add Billing Address</button>
-            </>
-          ) : null}
-
-          <br />
-          <div className='editting-btns-container'>
-            <OutlinedButton
-              wideBtn={false}
-              type='submit'
-              text='Save'
+        <>
+          {selectedItem === 'personal_info' && customer && (
+            <PersoanlDetails
+              customer={customer}
+              handleEditToggle={handleEditToggle}
             />
-            <button
-              className='outlinedButton editting-cancel'
-              onClick={handleEditToggle}
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
+          )}
+          {selectedItem === 'addresses' && customer && (
+            <Addresses
+              customer={customer}
+              shippingAddresses={shippingAddresses}
+              billingAddresses={billingAddresses}
+              handleEditToggle={handleEditToggle}
+            />
+          )}
+          {/* {selectedItem === 'reset_password' && <ResetPassword handleEditToggle={handleEditToggle} />} */}
+        </>
       ) : (
         <div id='profile-view'>
           {selectedItem === 'personal_info' && (
@@ -439,12 +55,12 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
           {selectedItem === 'addresses' && (
             <div className='addresses-container'>
               <h3>Shipping addresses</h3>
-              {shippingAddresses.map((address) => {
+              {shippingAddresses?.map((address) => {
                 const isDefaultShppingAddress = isDefault(address, customer?.defaultShippingAddressId);
                 return (
                   <div
                     key={address.id}
-                    className='address-container'
+                    className={'address-container no-edit' + (isDefaultShppingAddress ? ' default' : '')}
                   >
                     {isDefaultShppingAddress && <h4>Default Shipping Address</h4>}
                     <div className='address__label-value-wrapper'>
@@ -467,13 +83,18 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
                 );
               })}
 
+              <div className='profile-form__spacer'></div>
+              <hr />
+              <hr />
+              <div className='profile-form__spacer'></div>
+
               <h3>Billing addresses</h3>
-              {billingAddresses.map((address) => {
-                const isDefaultBillingAddress = isDefault(address, customer?.defaultShippingAddressId);
+              {billingAddresses?.map((address) => {
+                const isDefaultBillingAddress = isDefault(address, customer?.defaultBillingAddressId);
                 return (
                   <div
                     key={address.id}
-                    className='address-container'
+                    className={'address-container no-edit' + (isDefaultBillingAddress ? ' default' : '')}
                   >
                     {isDefaultBillingAddress && <h4>Default Billing Address</h4>}
                     <div className='address__label-value-wrapper'>
@@ -497,6 +118,13 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
               })}
             </div>
           )}
+
+          {/* {selectedItem === 'reset_password' && (
+            <div className='address__label-value-wrapper'>
+              <span className='address-info__label'>Password</span>
+              <span>******</span>
+            </div>
+          )} */}
         </div>
       )}
 
@@ -508,7 +136,6 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
           Edit
         </button>
       )}
-      <Loader isLoading={isLoading} />
     </div>
   );
 };

--- a/src/components/profile/profileForm/ProfileForm.tsx
+++ b/src/components/profile/profileForm/ProfileForm.tsx
@@ -5,6 +5,7 @@ import { Address } from '@commercetools/platform-sdk';
 import PersoanlDetails from '../personalDetails/PersonalDetails';
 import Addresses from '../addresses/Addresses';
 import './ProfileForm.css';
+import ResetPassword from '../resetPassword/ResetPassword';
 
 interface IProfileFormProps {
   selectedItem: string;
@@ -39,7 +40,7 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
               handleEditToggle={handleEditToggle}
             />
           )}
-          {/* {selectedItem === 'reset_password' && <ResetPassword handleEditToggle={handleEditToggle} />} */}
+          {selectedItem === 'change_password' && <ResetPassword handleEditToggle={handleEditToggle} />}
         </>
       ) : (
         <div id='profile-view'>
@@ -119,12 +120,12 @@ export const ProfileForm = ({ selectedItem }: IProfileFormProps): JSX.Element =>
             </div>
           )}
 
-          {/* {selectedItem === 'reset_password' && (
+          {selectedItem === 'change_password' && (
             <div className='address__label-value-wrapper'>
               <span className='address-info__label'>Password</span>
-              <span>******</span>
+              <span>********</span>
             </div>
-          )} */}
+          )}
         </div>
       )}
 

--- a/src/components/profile/resetPassword/ResetPassword.tsx
+++ b/src/components/profile/resetPassword/ResetPassword.tsx
@@ -1,0 +1,63 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import Input from '../../../shared/ui/Input/Input';
+import { OutlinedButton } from '../../../shared/button/outlinedButton/OutlinedButton';
+import validationSchema from './validationSchema';
+
+interface IResetPassword {
+  password: string;
+}
+
+const ResetPassword = ({ handleEditToggle }: { handleEditToggle: () => void }): JSX.Element => {
+  const { control, handleSubmit } = useForm<IResetPassword>({
+    defaultValues: {
+      password: '',
+    },
+    resolver: yupResolver(validationSchema) as Resolver<IResetPassword>,
+    mode: 'all',
+  });
+
+  const onSubmit = (data: IResetPassword) => {
+    return 5;
+  };
+
+  return (
+    <form
+      className='profile-form'
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Controller
+        control={control}
+        name='password'
+        render={({ field, fieldState }) => (
+          <Input
+            type='password'
+            id='password'
+            placeholder='Enter new password'
+            autoComplete='password'
+            value={field.value}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            error={fieldState.error?.message}
+          />
+        )}
+      />
+
+      <div className='editting-btns-container'>
+        <OutlinedButton
+          wideBtn={false}
+          type='submit'
+          text='Save'
+        />
+        <button
+          className='outlinedButton editting-cancel'
+          onClick={handleEditToggle}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ResetPassword;

--- a/src/components/profile/resetPassword/ResetPassword.tsx
+++ b/src/components/profile/resetPassword/ResetPassword.tsx
@@ -3,22 +3,46 @@ import { Controller, Resolver, useForm } from 'react-hook-form';
 import Input from '../../../shared/ui/Input/Input';
 import { OutlinedButton } from '../../../shared/button/outlinedButton/OutlinedButton';
 import validationSchema from './validationSchema';
+import { useAppDispatch } from '../../../hooks/reduxHooks';
+import { ChangePassword } from '../../../store/slices/customerSlice';
+import { setLoading } from '../../../store/slices/productSlice';
 
-interface IResetPassword {
-  password: string;
+interface IChnagePassword {
+  currentPassword: string;
+  newPassword: string;
 }
 
 const ResetPassword = ({ handleEditToggle }: { handleEditToggle: () => void }): JSX.Element => {
-  const { control, handleSubmit } = useForm<IResetPassword>({
+  const dispatch = useAppDispatch();
+
+  const { control, handleSubmit } = useForm<IChnagePassword>({
     defaultValues: {
-      password: '',
+      currentPassword: '',
+      newPassword: '',
     },
-    resolver: yupResolver(validationSchema) as Resolver<IResetPassword>,
+    resolver: yupResolver(validationSchema) as Resolver<IChnagePassword>,
     mode: 'all',
   });
 
-  const onSubmit = (data: IResetPassword) => {
-    return 5;
+  const onSubmit = (data: IChnagePassword) => {
+    if (data.currentPassword.trim() && data.newPassword.trim()) {
+      const chnagePasswordFields: IChnagePassword = {
+        currentPassword: data.currentPassword.trim(),
+        newPassword: data.newPassword.trim(),
+      };
+
+      setLoading(true);
+      void dispatch(ChangePassword(chnagePasswordFields)).then((response) => {
+        if (ChangePassword.fulfilled.match(response)) {
+          const customerData = response.payload;
+          if (customerData) {
+            alert('Password Successfully Chnaged!');
+          }
+          handleEditToggle();
+          setLoading(false);
+        }
+      });
+    }
   };
 
   return (
@@ -26,15 +50,36 @@ const ResetPassword = ({ handleEditToggle }: { handleEditToggle: () => void }): 
       className='profile-form'
       onSubmit={handleSubmit(onSubmit)}
     >
+      <label htmlFor='currentPassword'>Current Password: </label>
       <Controller
         control={control}
-        name='password'
+        name='currentPassword'
         render={({ field, fieldState }) => (
           <Input
+            name='currentPassword'
             type='password'
-            id='password'
+            id='currentPassword'
+            placeholder='Enter current password'
+            autoComplete='currentPassword'
+            value={field.value}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            error={fieldState.error?.message}
+          />
+        )}
+      />
+
+      <label htmlFor='newPassword'>New Password: </label>
+      <Controller
+        control={control}
+        name='newPassword'
+        render={({ field, fieldState }) => (
+          <Input
+            name='newPassword'
+            type='password'
+            id='newPassword'
             placeholder='Enter new password'
-            autoComplete='password'
+            autoComplete='newPassword'
             value={field.value}
             onChange={field.onChange}
             onBlur={field.onBlur}

--- a/src/components/profile/resetPassword/validationSchema.ts
+++ b/src/components/profile/resetPassword/validationSchema.ts
@@ -1,0 +1,18 @@
+import * as Yup from 'yup';
+
+const validationSchema = Yup.object().shape({
+  password: Yup.string()
+    .test(
+      'no-whitespace',
+      'Whitespace is not allowed',
+      (value: string | undefined) => !/^\s+|\s+$/g.test(value as string)
+    )
+    .min(8, 'This password is too short, must be at least 8 characters long')
+    .max(50, 'This password is too long')
+    .matches(/[A-Z]/, 'The password must contain capital letter')
+    .matches(/[a-z]/, 'The password must contain a lowercase letter')
+    .matches(/\d/, 'The password must contain a digit')
+    .matches(/[!%*?&]/, 'Use spec symbols (!,%,*,?,&)'),
+});
+
+export default validationSchema;

--- a/src/components/profile/resetPassword/validationSchema.ts
+++ b/src/components/profile/resetPassword/validationSchema.ts
@@ -1,7 +1,19 @@
 import * as Yup from 'yup';
 
 const validationSchema = Yup.object().shape({
-  password: Yup.string()
+  currentPassword: Yup.string()
+    .test(
+      'no-whitespace',
+      'Whitespace is not allowed',
+      (value: string | undefined) => !/^\s+|\s+$/g.test(value as string)
+    )
+    .min(8, 'This password is too short, must be at least 8 characters long')
+    .max(50, 'This password is too long')
+    .matches(/[A-Z]/, 'The password must contain capital letter')
+    .matches(/[a-z]/, 'The password must contain a lowercase letter')
+    .matches(/\d/, 'The password must contain a digit')
+    .matches(/[!%*?&]/, 'Use spec symbols (!,%,*,?,&)'),
+  newPassword: Yup.string()
     .test(
       'no-whitespace',
       'Whitespace is not allowed',

--- a/src/store/slices/customerSlice.ts
+++ b/src/store/slices/customerSlice.ts
@@ -19,6 +19,7 @@ import {
   CustomerRemoveAddressAction,
   CustomerSetDefaultShippingAddressAction,
   CustomerSetDefaultBillingAddressAction,
+  CustomerChangePassword,
 } from '@commercetools/platform-sdk';
 import { ClientType } from '../../types/Enums';
 
@@ -122,7 +123,6 @@ export const UpdateCustomer = createAsyncThunk(
     const existingCustomer = state.customers.customer;
 
     if (!existingCustomer) {
-      // Handle the case where the existing customer is not found
       return thunkAPI.rejectWithValue('Existing customer not found');
     }
 
@@ -252,21 +252,38 @@ export const UpdateCustomer = createAsyncThunk(
   }
 );
 
-// export const ChangePassword = createAsyncThunk(
-//   'customer/changePassword',
-//   async (data: CustomerChangePassword, thunkAPI) => {
-//     const state: RootState = thunkAPI.getState() as RootState;
-//     const { id } = data;
-//     const apiInstance = state.customers.apiInstance;
-//     try {
-//       const updatedCustomer = await apiInstance.changePassword(id, data);
+interface ChnagePasswordFields {
+  currentPassword: string;
+  newPassword: string;
+}
 
-//       return Object.keys(updatedCustomer).length ? updatedCustomer : null;
-//     } catch (error) {
-//       throw new Error('Error while updating customer');
-//     }
-//   }
-// );
+export const ChangePassword = createAsyncThunk(
+  'customer/changePassword',
+  async (data: ChnagePasswordFields, thunkAPI) => {
+    const state: RootState = thunkAPI.getState() as RootState;
+    const apiInstance = state.customers.apiInstance;
+
+    const existingCustomer = state.customers.customer;
+
+    if (!existingCustomer) {
+      return thunkAPI.rejectWithValue('Existing customer not found');
+    }
+
+    const chnageCustomerPassword: CustomerChangePassword = {
+      id: existingCustomer.id,
+      version: existingCustomer.version,
+      currentPassword: data.currentPassword,
+      newPassword: data.newPassword,
+    };
+
+    try {
+      const updatedCustomer: Customer | null = await apiInstance.changePassword(chnageCustomerPassword);
+      return updatedCustomer;
+    } catch (error) {
+      throw new Error('Error while changing password!');
+    }
+  }
+);
 
 const customerSlice = createSlice({
   name: 'customer',
@@ -303,11 +320,11 @@ const customerSlice = createSlice({
         state.customer = action.payload || state.customer;
       }
     });
-    // builder.addCase(ChangePassword.fulfilled, (state, action) => {
-    //   if (action.payload) {
-    //     state.customer = action.payload || state.customer;
-    //   }
-    // });
+    builder.addCase(ChangePassword.fulfilled, (state, action) => {
+      if (action.payload) {
+        state.customer = action.payload || state.customer;
+      }
+    });
   },
 });
 // eslint-disable-next-line

--- a/src/store/slices/customerSlice.ts
+++ b/src/store/slices/customerSlice.ts
@@ -11,6 +11,14 @@ import {
   CustomerSetFirstNameAction,
   CustomerSetLastNameAction,
   CustomerSetDateOfBirthAction,
+  Address,
+  CustomerChangeAddressAction,
+  CustomerAddAddressAction,
+  CustomerAddBillingAddressIdAction,
+  CustomerAddShippingAddressIdAction,
+  CustomerRemoveAddressAction,
+  CustomerSetDefaultShippingAddressAction,
+  CustomerSetDefaultBillingAddressAction,
 } from '@commercetools/platform-sdk';
 import { ClientType } from '../../types/Enums';
 
@@ -20,6 +28,15 @@ type CustomerUpdateFields = {
   setLastName?: { lastName: string };
   setEmail?: { email: string };
   setDateOfBirth?: { dateOfBirth: string };
+  changeShippingAddress?: { addressId?: string; address: Address };
+  changeBillingAddress?: { addressId?: string; address: Address };
+  addBillingAddress?: { address: Address };
+  addShippingAddress?: { address: Address };
+  addBillingAddressId?: { addressId?: string };
+  addShippingAddressId?: { addressId?: string };
+  removeAddress?: { addressId?: string };
+  setDefaultShippingAddress?: { addressId?: string };
+  setDefaultBillingAddress?: { addressId?: string };
 };
 
 interface UpdateCustomerData {
@@ -145,6 +162,80 @@ export const UpdateCustomer = createAsyncThunk(
                 dateOfBirth: (value as { dateOfBirth: string }).dateOfBirth,
               } as CustomerSetDateOfBirthAction,
             ];
+          case 'changeShippingAddress':
+            return [
+              ...acc,
+              {
+                action: 'changeAddress',
+                addressId: (value as { addressId: string; address: Address }).addressId,
+                address: (value as { addressId: string; address: Address }).address,
+              } as CustomerChangeAddressAction,
+            ];
+          case 'changeBillingAddress':
+            return [
+              ...acc,
+              {
+                action: 'changeAddress',
+                addressId: (value as { addressId: string; address: Address }).addressId,
+                address: (value as { addressId: string; address: Address }).address,
+              } as CustomerChangeAddressAction,
+            ];
+          case 'addBillingAddress':
+            return [
+              ...acc,
+              {
+                action: 'addAddress',
+                address: (value as { address: Address }).address,
+              } as CustomerAddAddressAction,
+            ];
+          case 'addBillingAddressId':
+            return [
+              ...acc,
+              {
+                action: 'addBillingAddressId',
+                addressId: (value as { addressId: string }).addressId,
+              } as CustomerAddBillingAddressIdAction,
+            ];
+          case 'addShippingAddress':
+            return [
+              ...acc,
+              {
+                action: 'addAddress',
+                address: (value as { address: Address }).address,
+              } as CustomerAddAddressAction,
+            ];
+          case 'addShippingAddressId':
+            return [
+              ...acc,
+              {
+                action: 'addShippingAddressId',
+                addressId: (value as { addressId: string }).addressId,
+              } as CustomerAddShippingAddressIdAction,
+            ];
+          case 'removeAddress':
+            return [
+              ...acc,
+              {
+                action: 'removeAddress',
+                addressId: (value as { addressId: string }).addressId,
+              } as CustomerRemoveAddressAction,
+            ];
+          case 'setDefaultShippingAddress':
+            return [
+              ...acc,
+              {
+                action: 'setDefaultShippingAddress',
+                addressId: (value as { addressId: string }).addressId,
+              } as CustomerSetDefaultShippingAddressAction,
+            ];
+          case 'setDefaultBillingAddress':
+            return [
+              ...acc,
+              {
+                action: 'setDefaultBillingAddress',
+                addressId: (value as { addressId: string }).addressId,
+              } as CustomerSetDefaultBillingAddressAction,
+            ];
           default:
             return acc;
         }
@@ -153,12 +244,29 @@ export const UpdateCustomer = createAsyncThunk(
 
     try {
       const updatedCustomer = await apiInstance.updateCustomer(customerId, updatedCustomerData);
-      return updatedCustomer;
+
+      return Object.keys(updatedCustomer).length ? updatedCustomer : null;
     } catch (error) {
       throw new Error('Error while updating customer');
     }
   }
 );
+
+// export const ChangePassword = createAsyncThunk(
+//   'customer/changePassword',
+//   async (data: CustomerChangePassword, thunkAPI) => {
+//     const state: RootState = thunkAPI.getState() as RootState;
+//     const { id } = data;
+//     const apiInstance = state.customers.apiInstance;
+//     try {
+//       const updatedCustomer = await apiInstance.changePassword(id, data);
+
+//       return Object.keys(updatedCustomer).length ? updatedCustomer : null;
+//     } catch (error) {
+//       throw new Error('Error while updating customer');
+//     }
+//   }
+// );
 
 const customerSlice = createSlice({
   name: 'customer',
@@ -195,6 +303,11 @@ const customerSlice = createSlice({
         state.customer = action.payload || state.customer;
       }
     });
+    // builder.addCase(ChangePassword.fulfilled, (state, action) => {
+    //   if (action.payload) {
+    //     state.customer = action.payload || state.customer;
+    //   }
+    // });
   },
 });
 // eslint-disable-next-line

--- a/src/tests/pages/Header.test.tsx
+++ b/src/tests/pages/Header.test.tsx
@@ -72,7 +72,7 @@ describe('Header component tests', () => {
       </MemoryRouter>
     );
 
-    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Flowers')).toBeInTheDocument();
     expect(getByText('John')).toBeInTheDocument();
     expect(getByText('Log out')).toBeInTheDocument();
   });
@@ -123,7 +123,7 @@ describe('Header component tests', () => {
       </MemoryRouter>
     );
 
-    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Flowers')).toBeInTheDocument();
     expect(getByText('Login')).toBeInTheDocument();
     expect(getByText('Register')).toBeInTheDocument();
   });


### PR DESCRIPTION
Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md)

Screenshot:
![image](https://github.com/NataliaIv90/ecommerce-app/assets/126329090/5876a86f-03db-49b0-9214-3f3f1e0b4c61)


Deploy: [link](https://garden-with-flowers.netlify.app/)
score:15/15
Users can manage their addresses within the User Profile page using commercetools API, including adding new addresses, deleting existing ones, and updating address details.
Users can set their default billing and shipping addresses.
The system validates input address details according to the necessary criteria.
The application properly integrates with the commercetools API for address management purposes.

Screenshot:

![image](https://github.com/NataliaIv90/ecommerce-app/assets/126329090/d045d0e4-6127-4a4a-9916-2296b4c1b2fe)


Deploy: link
score: 15/15
Acceptance Criteria
Users can change their password separately from their other personal information on the User Profile page.
The system appropriately validates the new password based on the necessary criteria.
The user can save the changes, and is given a clear indication of the success or failure of this operation.