### PR TITLE
feat: add about us link in the header

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -6,6 +6,7 @@ import { API } from '../../api/API';
 import { getApiRoot } from '../../api/lib/Client';
 import PermIdentityOutlinedIcon from '@mui/icons-material/PermIdentityOutlined';
 import PersonAddAltOutlinedIcon from '@mui/icons-material/PersonAddAltOutlined';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import './Header.css';
 
 export const Header = (): JSX.Element => {
@@ -30,6 +31,14 @@ export const Header = (): JSX.Element => {
           </li>
           <li className='header__link'>
             <Link to='/catalog'>Catalog</Link>
+          </li>
+          <li className='header__link'>
+            <Link to='/about-us'>About us</Link>
+          </li>
+          <li className='header__link'>
+            <Link to='/cart'>
+              <ShoppingCartIcon />
+            </Link>
           </li>
           <li className='header__link'>
             {customer ? (


### PR DESCRIPTION
Task: [link](https://github.com/rolling-scopes-school/js-fe-course-en/blob/main/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_24.md)

Screenshot:
![image](https://github.com/NataliaIv90/ecommerce-app/assets/126329090/e2fea549-05d3-40d3-a5c5-f825e925cc07)


Deploy: [link](https://garden-with-flowers-test.netlify.app/)



Score: 5/5


An icon or link to the About Us page is included in the header navigation 🖼️🔗.
The icon or link is clearly visible and fits the overall design of the website 🌐.
Clicking on the icon or link takes the user directly to the About Us page 🚏.